### PR TITLE
PP-15838 Clarify API key security guidance

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -100,11 +100,13 @@ Do not add an allow list of IP addresses to your firewall, because GOV.UK Pay’
 
 GOV.UK Pay authenticates API requests with [OAuth2 HTTP bearer tokens](http://tools.ietf.org/html/rfc6750).
 
-When you make an API requests, you need to use an `Authorization` HTTP header to provide your API key, with a `Bearer` prefix. For example:
+When you make an API request, you need to use an `Authorization` HTTP header to provide your API key, with a `Bearer` prefix. For example:
 
 ```text
 Authorization: Bearer {YOUR_API_KEY}
 ```
+
+[Read more about securing your API keys](/security/#securing-your-developer-keys).
 
 ## Rate limits
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -1,13 +1,11 @@
 ---
 title: Quick start
-last_reviewed_on: 2026-03-02
+last_reviewed_on: 2026-09-04
 review_in: 6 months
 weight: 1200
 ---
 
 # Quick start
-
-<%= warning_text('You must store your API keys securely. You must not share this key in publicly accessible documents or repositories. You must not share it with anyone who should not be using the GOV.UK Pay API directly.') %>
 
 Read this section to learn about what to do to get started with GOV.UK Pay.
 
@@ -80,9 +78,9 @@ You can still use test API keys for a service after it goes live.
 
 1. Select **Create a new API key**.
 
-Make sure you [keep your API keys safe](/security/#securing-your-developer-keys).
+<%= warning_text('You must store API keys securely. You must not include them in emails, support tickets or other messages to GOV.UK Pay. You must not put them in publicly accessible documents or repositories. Share API keys only with people or organisations that need them.<br><a href="/security/#securing-your-developer-keys">Read more about securing your API keys</a>.') %>
 
-<%= warning_text('Only use test API keys in sandbox or &#39;not live yet&#39; modes. Do not use a live API key in these modes. It will not work properly.') %>
+Use test API keys only in sandbox or &#39;not live yet&#39; modes. Live API keys will not work properly in these modes.
 
 ### Make a test API request
 

--- a/source/security/index.html.md.erb
+++ b/source/security/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Security and compliance
-last_reviewed_on: 2025-11-13
+last_reviewed_on: 2026-09-04
 review_in: 6 months
 weight: 9200
 ---
@@ -17,13 +17,13 @@ Do not disclose the details of a suspected breach publicly until it has been fix
 
 GOV.UK Pay lets you create as many API keys as you want.
 
-We recommend letting all your developers experiment with their own test keys in
-sandbox or 'not live yet' mode, but keys for real integrations should only be shared
-with the minimum number of people necessary.
+You must store your API keys securely. You must not include API keys in emails, support tickets or other messages to GOV.UK Pay.
 
-This is because these keys can be
-used to create and manipulate payments. You must not commit these keys to public
-source code repositories.
+Share API keys only with people or organisations that need them. If you share an API key with a third-party supplier, your organisation is responsible for sharing it securely and making sure the supplier handles it securely.
+
+Test API keys are less sensitive than live API keys, but you should still handle them securely. We recommend letting all your developers experiment with their own test keys in sandbox or 'not live yet' mode.
+
+You should limit access to live API keys to the minimum number of people necessary. Live API keys can be used to create and manipulate payments, and to read all transaction data. You must not commit them to public source code repositories.
 
 Follow these steps to revoke your API key immediately if you believe it has been accidentally shared or compromised:
 

--- a/source/switching_to_live/index.html.md.erb
+++ b/source/switching_to_live/index.html.md.erb
@@ -109,8 +109,10 @@ You make a real payment using either:
 
 1. Create a new live API key.
 
-1. [Make a real payment](/making_payments/#take-a-payment) using the new live API key.
+    [Read more about securing your API keys](/security/#securing-your-developer-keys).
 
+1. [Make a real payment](/making_payments/#take-a-payment) using the new live API key.
+    
     You must use a real payment card. Use a small amount, because GOV.UK Pay will take the payment from the card you use.
 
     If you want to see the payment in your bank account, make sure the payment amount will be [above the minimum payout](/reporting) after your PSP has taken their fees. If your PSP is Stripe, we recommend a test payment of at least £2.


### PR DESCRIPTION
### Context
A recent Pay security incident highlighted the need to tighten the current wording about API key security on different pages of Pay technical documentation.

### Changes proposed in this pull request

- Move and reword the API key warning on the Quick start page.
- Expand the API key security guidance on the Security and compliance page.
- Add links to the API key security section on the Security and compliance page from the API reference Authentication section and the Go live page.

### Guidance to review

- Quick start page
- Security and compliance page
- Authentication section of API reference
- Go live page